### PR TITLE
Extend HealthLake module with possible client_credentials grant_type

### DIFF
--- a/healthlake/cognito.tf
+++ b/healthlake/cognito.tf
@@ -1,5 +1,3 @@
-# cognito.tf
-
 resource "aws_cognito_user_pool" "main" {
   count = var.smart_on_fhir ? 1 : 0
 
@@ -111,19 +109,11 @@ resource "aws_cognito_user_pool_client" "client" {
 
 
   prevent_user_existence_errors        = "ENABLED"
-  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows                  = [var.grant_type]
   allowed_oauth_flows_user_pool_client = true
 
 
-  allowed_oauth_scopes = [
-    "openid",
-    "profile",
-    "email",
-    "phone",
-    "launch/patient",
-    "system/*.*",
-    "patient/*.read"
-  ]
+  allowed_oauth_scopes = var.grant_type == "code" ? local.auth_code_scopes : local.client_credentials_scopes
 
   callback_urls = var.cognito_callback_urls
   logout_urls   = var.cognito_logout_urls

--- a/healthlake/common.tf
+++ b/healthlake/common.tf
@@ -1,2 +1,19 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+locals {
+  auth_code_scopes = [
+    "openid",
+    "profile",
+    "email",
+    "phone",
+    "launch/patient",
+    "system/*.*",
+    "patient/*.read"
+  ]
+  client_credentials_scopes = [
+    "launch/patient",
+    "system/*.*",
+    "patient/*.read"
+  ]
+}

--- a/healthlake/variables.tf
+++ b/healthlake/variables.tf
@@ -176,3 +176,15 @@ variable "cognito_test_users" {
   }))
   default = []
 }
+
+variable "grant_type" {
+  type        = string
+  description = "OAuth grant type - either 'authorization_code' or 'client_credentials'"
+  validation {
+    condition     = contains(["code", "client_credentials"], var.grant_type)
+    error_message = "grant_type must be either 'authorization_code' or 'client_credentials'"
+  }
+
+  default = "authorization_code"
+}
+


### PR DESCRIPTION
This PR fixes the inability to configure additional `grant_type` options in AWS Cognito for the HealthLake module